### PR TITLE
Implement alternative version of zeros

### DIFF
--- a/src/ArrayAllocators.jl
+++ b/src/ArrayAllocators.jl
@@ -212,4 +212,6 @@ elseif Sys.isunix()
     const MemAlign = PosixMemAlign
 end
 
+include("zeros.jl")
+
 end # module ArrayAllocators

--- a/src/ByteCalculators.jl
+++ b/src/ByteCalculators.jl
@@ -29,6 +29,12 @@ abstract type AbstractByteCalculator{T} end
 function (::Type{B})(dims::Int...) where {T, B <: AbstractByteCalculator{T}}
     return B(dims)
 end
+function (::Type{B})(ind::AbstractUnitRange...) where {T, B <: AbstractByteCalculator{T}}
+    return B(map(length, ind))
+end
+function (::Type{B})(ind::NTuple{N,AbstractUnitRange}) where {N, T, B <: AbstractByteCalculator{T}}
+    return B(map(length, ind))
+end
 elsize(::AbstractByteCalculator{T}) where T = isbitstype(T) ? sizeof(T) : sizeof(Ptr)
 nbytes(b::AbstractByteCalculator{T}) where T = elsize(b) * length(b)
 

--- a/src/zeros.jl
+++ b/src/zeros.jl
@@ -1,0 +1,31 @@
+"""
+    ArrayAllocators.zeros(T=Float64, dims::Integer...)
+    ArrayAllocators.zeros(T=Float64, dims::Dims)
+
+Return an Array with element type `T` with size `dims` filled by `0`s via
+`calloc`. Depending on the libc implementation, the operating system may lazily
+wait for a page fault before obtaining memory initialized to `0`.
+This is an alternative to `Base.zeros` that always fills the array with `0`
+eagerly. 
+
+# Examples
+```julia
+julia> @time ArrayAllocators.zeros(Int, 3200, 3200);
+  0.000026 seconds (4 allocations: 78.125 MiB)
+
+julia> @time Base.zeros(Int, 3200, 3200);
+  0.133595 seconds (2 allocations: 78.125 MiB, 67.36% gc time)
+ 
+julia> ArrayAllocators.zeros(Int, 256, 256) == Base.zeros(Int, 256, 256)
+true
+```
+"""
+function zeros(::Type{T}, dims::Integer...) where T
+    return Array{T}(calloc, dims...)
+end
+function zeros(::Type{T}, dims::Dims) where T
+    return Array{T}(calloc, dims)
+end
+zeros(dims::Integer...) = zeros(Float64, dims)
+zeros(dims::Dims) = zeros(Float64, dims)
+

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -14,7 +14,12 @@ using SafeByteCalculators
     A = zeros(UInt8, 2048, 2048);
     B = Array{UInt8}(calloc, 2048, 2048);
     M = Array{UInt8}(malloc, 1024, 4096)
+    Z = ArrayAllocators.zeros(UInt8, 2048, 2048)
+    Z2 = ArrayAllocators.zeros(UInt8, (2048, 2048))
     @test A == B
+    @test A == Z
+    @test size(Z) == (2048, 2048)
+    @test size(Z2) == (2048, 2048)
     @test size(M) == (1024, 4096)
     
     @test_throws OverflowError Array{UInt8}(calloc, 20480000, typemax(Int64))


### PR DESCRIPTION
From #7 it seems there may be an expectation for this package to implement a new version of `zeros` based on `calloc` that can be used a drop in replacement for `Base.zeros`.

I am somewhat reluctant to add this since the `Array{T}(...)` syntax is preferred. However, perhaps some will find this useful.